### PR TITLE
API 6606 principals

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,14 @@ data from MPI to determine which VistA instances are likely to contain meaningfu
 ```
 {
   principal: {
-    applicationProxyUser: SOME APP PROXY, .. Optional application proxy user
+    applicationProxyUser: SOME APP PROXY, .. (Optional) Application proxy user
     accessCode: ABC123, .................... Access code
     verifyCode: XYZ987, .................... Verify code
+  }
+  siteSpecificPrincipals: { ................ (Optional) map of principals to be used for a specific site.
+    ${site}: { <principal> },
+    ${site}: { <principal> },
+    ...
   }
   target: { ................................ One of forPatient or include must be specified. You may specify both.
     forPatient: 1234567890V123456,  ........ Determine appropriate VistA instances for the patient
@@ -72,6 +77,26 @@ data from MPI to determine which VistA instances are likely to contain meaningfu
 }
 ```
 
+- `siteSpecificPrincipals` can be used to override the principals to be used at a specific site. The default `principal`
+  will be used for each site unless a specific entry is provided. For example, consider a request that is made
+  against `605`, `673`, and `488`. If the `siteSpecificPrincipals` is provided with an entry for `605`. The
+  default `principal` would be used for `673` and `488`, but site specific principal would be used for `605`. This
+  capability is intented to support situations where users are in transition at specific sites. For example, users are
+  in the process of being created or their credentials are being changed at different sites.
+  ```
+  {
+  "principal": {
+    "accessCode": "ABCD"
+    "verifyCode": "XYZ"
+  },
+  "siteSpecificPrincipals": {
+    "605": {
+      "applicationProxyUser": "AWE SOME PROXY",
+      "accessCode": "1234"
+      "verifyCode": "5678"
+    }
+  },
+  ```
 - Vista `coordinates` are specified as `host:port:divisionIen:timezoneId`. For
   example, `10.11.12.123:18123:456:America/New_York`. See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   for time zone IDs.

--- a/charon-api/spotbugs-excludes.xml
+++ b/charon-api/spotbugs-excludes.xml
@@ -7,6 +7,7 @@
   -->
   <Match>
     <Or>
+      <Class name="gov.va.api.lighthouse.charon.api.RpcRequest"/>
       <Class name="gov.va.api.lighthouse.charon.api.RpcResponse"/>
       <Class name="gov.va.api.lighthouse.charon.api.RpcVistaTargets"/>
     </Or>

--- a/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcRequest.java
+++ b/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcRequest.java
@@ -2,6 +2,8 @@ package gov.va.api.lighthouse.charon.api;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import java.util.HashMap;
+import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -13,5 +15,14 @@ import lombok.Data;
 public class RpcRequest {
   @NotNull @Valid private RpcDetails rpc;
   @NotNull @Valid private RpcPrincipal principal;
+  private Map<String, @Valid RpcPrincipal> siteSpecificPrincipals;
   @NotNull @Valid private RpcVistaTargets target;
+
+  /** Lazy initializer. */
+  public Map<String, @Valid RpcPrincipal> siteSpecificPrincipals() {
+    if (siteSpecificPrincipals == null) {
+      siteSpecificPrincipals = new HashMap<>();
+    }
+    return siteSpecificPrincipals;
+  }
 }

--- a/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcRequest.java
+++ b/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcRequest.java
@@ -19,7 +19,7 @@ public class RpcRequest {
   @NotNull @Valid private RpcVistaTargets target;
 
   /** Lazy initializer. */
-  public Map<String, @Valid RpcPrincipal> siteSpecificPrincipals() {
+  public Map<String, RpcPrincipal> siteSpecificPrincipals() {
     if (siteSpecificPrincipals == null) {
       siteSpecificPrincipals = new HashMap<>();
     }

--- a/charon-api/src/test/java/gov/va/api/lighthouse/charon/api/RpcRequestTest.java
+++ b/charon-api/src/test/java/gov/va/api/lighthouse/charon/api/RpcRequestTest.java
@@ -1,39 +1,88 @@
 package gov.va.api.lighthouse.charon.api;
 
 import static gov.va.api.lighthouse.charon.api.RoundTrip.assertRoundTrip;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class RpcRequestTest {
-  @Test
-  void roundTrip() {
-    var sample =
-        RpcRequest.builder()
-            .principal(RpcPrincipal.builder().accessCode("ac").verifyCode("vc").build())
-            .target(
-                RpcVistaTargets.builder()
-                    .forPatient("p1")
-                    .include(List.of("1"))
-                    .exclude(List.of("2"))
-                    .build())
-            .rpc(
-                RpcDetails.builder()
-                    .name("FAUX NAME")
-                    .context("FAUX CONTEXT")
-                    .parameters(
-                        List.of(
-                            RpcDetails.Parameter.builder().string("").build(),
-                            RpcDetails.Parameter.builder().string("a").build(),
-                            RpcDetails.Parameter.builder().ref("").build(),
-                            RpcDetails.Parameter.builder().ref("b").build(),
-                            RpcDetails.Parameter.builder().array(List.of()).build(),
-                            RpcDetails.Parameter.builder().array(List.of("c")).build(),
-                            RpcDetails.Parameter.builder().namedArray(Map.of()).build(),
-                            RpcDetails.Parameter.builder().namedArray(Map.of("d", "e")).build()))
-                    .build())
-            .build();
+
+  static Stream<Arguments> roundTrip() {
+    return Stream.of(arguments(v0()), arguments(v1()));
+  }
+
+  private static RpcRequest v0() {
+    return RpcRequest.builder()
+        .principal(RpcPrincipal.builder().accessCode("ac").verifyCode("vc").build())
+        .target(
+            RpcVistaTargets.builder()
+                .forPatient("p1")
+                .include(List.of("1"))
+                .exclude(List.of("2"))
+                .build())
+        .rpc(
+            RpcDetails.builder()
+                .name("FAUX NAME")
+                .context("FAUX CONTEXT")
+                .parameters(
+                    List.of(
+                        RpcDetails.Parameter.builder().string("").build(),
+                        RpcDetails.Parameter.builder().string("a").build(),
+                        RpcDetails.Parameter.builder().ref("").build(),
+                        RpcDetails.Parameter.builder().ref("b").build(),
+                        RpcDetails.Parameter.builder().array(List.of()).build(),
+                        RpcDetails.Parameter.builder().array(List.of("c")).build(),
+                        RpcDetails.Parameter.builder().namedArray(Map.of()).build(),
+                        RpcDetails.Parameter.builder().namedArray(Map.of("d", "e")).build()))
+                .build())
+        .build();
+  }
+
+  private static RpcRequest v1() {
+    return RpcRequest.builder()
+        .principal(RpcPrincipal.builder().accessCode("ac").verifyCode("vc").build())
+        .target(
+            RpcVistaTargets.builder()
+                .forPatient("p1")
+                .include(List.of("1"))
+                .exclude(List.of("2"))
+                .build())
+        .siteSpecificPrincipals(
+            Map.of(
+                "123",
+                RpcPrincipal.applicationProxyUserBuilder()
+                    .applicationProxyUser("A1")
+                    .accessCode("ac1")
+                    .verifyCode("vc1")
+                    .build(),
+                "456",
+                RpcPrincipal.standardUserBuilder().accessCode("ac2").verifyCode("vc2").build()))
+        .rpc(
+            RpcDetails.builder()
+                .name("FAUX NAME")
+                .context("FAUX CONTEXT")
+                .parameters(
+                    List.of(
+                        RpcDetails.Parameter.builder().string("").build(),
+                        RpcDetails.Parameter.builder().string("a").build(),
+                        RpcDetails.Parameter.builder().ref("").build(),
+                        RpcDetails.Parameter.builder().ref("b").build(),
+                        RpcDetails.Parameter.builder().array(List.of()).build(),
+                        RpcDetails.Parameter.builder().array(List.of("c")).build(),
+                        RpcDetails.Parameter.builder().namedArray(Map.of()).build(),
+                        RpcDetails.Parameter.builder().namedArray(Map.of("d", "e")).build()))
+                .build())
+        .build();
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void roundTrip(RpcRequest sample) {
     assertRoundTrip(sample);
   }
 }

--- a/charon-tests/src/test/java/gov/va/api/lighthouse/charon/tests/RpcRequestIT.java
+++ b/charon-tests/src/test/java/gov/va/api/lighthouse/charon/tests/RpcRequestIT.java
@@ -3,8 +3,12 @@ package gov.va.api.lighthouse.charon.tests;
 import static gov.va.api.lighthouse.charon.tests.TestOptions.assumeVistaIsAvailable;
 
 import gov.va.api.lighthouse.charon.api.RpcDetails;
+import gov.va.api.lighthouse.charon.api.RpcPrincipal;
 import gov.va.api.lighthouse.charon.api.RpcRequest;
 import gov.va.api.lighthouse.charon.api.RpcResponse;
+import gov.va.api.lighthouse.charon.api.RpcVistaTargets;
+import java.util.List;
+import java.util.Map;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
@@ -36,6 +40,32 @@ public class RpcRequestIT {
             .rpc(rpc)
             .principal(SystemDefinitions.get().avCodePrincipal())
             .target(SystemDefinitions.get().testTargets())
+            .build();
+    var response =
+        TestClients.rpcRequest(SystemDefinitions.get().charon().apiPath() + "rpc", body)
+            .expect(200)
+            .expectValid(RpcResponse.class);
+    log.info(response.toString());
+  }
+
+  @Test
+  void requestWithSiteSpecificPrincipals() {
+    assumeVistaIsAvailable();
+    RpcRequest body =
+        RpcRequest.builder()
+            .rpc(SystemDefinitions.get().testRpcs().stringRequestRpc())
+            .principal(
+                RpcPrincipal.standardUserBuilder()
+                    .accessCode("NOPE")
+                    .verifyCode("ALSO_NOPE")
+                    .build())
+            .siteSpecificPrincipals(
+                Map.of(
+                    SystemDefinitions.get().vistaSite(), SystemDefinitions.get().avCodePrincipal()))
+            .target(
+                RpcVistaTargets.builder()
+                    .include(List.of(SystemDefinitions.get().vistaSite()))
+                    .build())
             .build();
     var response =
         TestClients.rpcRequest(SystemDefinitions.get().charon().apiPath() + "rpc", body)

--- a/charon/invoke-rpc
+++ b/charon/invoke-rpc
@@ -37,7 +37,7 @@ cat $TEMPLATE | envsubst > $POST_ME
 if [ "${LOG_REQUEST:-false}" == true ]
 then
   echo "REQUEST:"
-  cat $POST_ME |  jq '.|.principal.accessCode="REDACTED"|.principal.verifyCode="REDACTED"'
+  cat $POST_ME |  jq '.' | sed -e 's/"\(access\|verify\)Code":.*/"\1Code": "REDACTED"/'
 fi
 
 curl \

--- a/charon/requests/vpr-get-patient-data-xml-with-site-specific-principal.json
+++ b/charon/requests/vpr-get-patient-data-xml-with-site-specific-principal.json
@@ -1,0 +1,29 @@
+{
+  "principal": {
+    "accessCode":"NOPE$VISTA_ACCESS_CODE",
+    "verifyCode":"NOPE$VISTA_VERIFY_CODE"
+  },
+  "siteSpecificPrincipals": {
+    "673": {
+      "applicationProxyUser":"$VISTA_APP_PROXY_USER",
+      "accessCode":"$VISTA_APP_PROXY_ACCESS_CODE",
+      "verifyCode":"$VISTA_APP_PROXY_VERIFY_CODE"
+    }
+  },
+  "target": {
+    "forPatient": "195607"
+  },
+  "rpc": {
+    "name":"VPR GET PATIENT DATA",
+    "context":"LHS RPC CONTEXT",
+    "parameters": [
+      {"string":";195607"},
+      {"string":"demographics;vitals"},
+      {"string":""},
+      {"string":""},
+      {"string":""},
+      {"string":""},
+      {"array": []}
+    ]
+  }
+}

--- a/charon/src/main/java/gov/va/api/lighthouse/charon/service/controller/ParallelRpcExecutor.java
+++ b/charon/src/main/java/gov/va/api/lighthouse/charon/service/controller/ParallelRpcExecutor.java
@@ -77,11 +77,14 @@ public class ParallelRpcExecutor implements RpcExecutor {
   private Map<String, Future<RpcInvocationResult>> invokeForEachTarget(
       RpcRequest request, List<ConnectionDetails> targets) {
     Map<String, Future<RpcInvocationResult>> futures = new HashMap<>(targets.size());
+    PrincipalResolution principals = PrincipalResolution.of(request);
     for (ConnectionDetails target : targets) {
       futures.put(
           target.name(),
           executor.submit(
-              () -> safelyInvoke(request, rpcInvokerFactory.create(request.principal(), target))));
+              () ->
+                  safelyInvoke(
+                      request, rpcInvokerFactory.create(principals.resolve(target), target))));
     }
     return futures;
   }

--- a/charon/src/main/java/gov/va/api/lighthouse/charon/service/controller/PrincipalResolution.java
+++ b/charon/src/main/java/gov/va/api/lighthouse/charon/service/controller/PrincipalResolution.java
@@ -1,0 +1,17 @@
+package gov.va.api.lighthouse.charon.service.controller;
+
+import gov.va.api.lighthouse.charon.api.RpcPrincipal;
+import gov.va.api.lighthouse.charon.api.RpcRequest;
+import gov.va.api.lighthouse.charon.service.config.ConnectionDetails;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+/** Provides selection of the best principal for the target. */
+@AllArgsConstructor(staticName = "of")
+public class PrincipalResolution {
+  @NonNull private final RpcRequest request;
+
+  public RpcPrincipal resolve(@NonNull ConnectionDetails target) {
+    return request.siteSpecificPrincipals().getOrDefault(target.name(), request.principal());
+  }
+}

--- a/charon/src/main/java/gov/va/api/lighthouse/charon/service/controller/PrincipalResolution.java
+++ b/charon/src/main/java/gov/va/api/lighthouse/charon/service/controller/PrincipalResolution.java
@@ -11,6 +11,7 @@ import lombok.NonNull;
 public class PrincipalResolution {
   @NonNull private final RpcRequest request;
 
+  /** Return the best credentials for the target. */
   public RpcPrincipal resolve(@NonNull ConnectionDetails target) {
     return request.siteSpecificPrincipals().getOrDefault(target.name(), request.principal());
   }

--- a/charon/src/test/java/gov/va/api/lighthouse/charon/service/controller/PrincipalResolutionTest.java
+++ b/charon/src/test/java/gov/va/api/lighthouse/charon/service/controller/PrincipalResolutionTest.java
@@ -1,0 +1,62 @@
+package gov.va.api.lighthouse.charon.service.controller;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import gov.va.api.lighthouse.charon.api.RpcDetails;
+import gov.va.api.lighthouse.charon.api.RpcPrincipal;
+import gov.va.api.lighthouse.charon.api.RpcRequest;
+import gov.va.api.lighthouse.charon.api.RpcVistaTargets;
+import gov.va.api.lighthouse.charon.service.config.ConnectionDetails;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PrincipalResolutionTest {
+
+  static Stream<Arguments> resolve() {
+    return Stream.of(
+        arguments(request(), target("a"), principal("default")),
+        arguments(request("b", "c"), target("a"), principal("default")),
+        arguments(request("b", "c"), target("b"), principal("b")),
+        arguments(request("b", "c"), target("c"), principal("c"))
+        //
+        );
+  }
+
+  static RpcRequest request(String... specific) {
+    return RpcRequest.builder()
+        .principal(principal("default"))
+        .siteSpecificPrincipals(
+            Stream.of(specific).collect(toMap(identity(), PrincipalResolutionTest::principal)))
+        .rpc(RpcDetails.builder().name("WHATEVER").context("WHATEVER CTX").build())
+        .target(RpcVistaTargets.builder().forPatient("WHOEVER").build())
+        .build();
+  }
+
+  static RpcPrincipal principal(String name) {
+    return RpcPrincipal.standardUserBuilder()
+        .accessCode("ac-" + name)
+        .verifyCode("vc-" + name)
+        .build();
+  }
+
+  static ConnectionDetails target(String name) {
+    return ConnectionDetails.builder()
+        .name(name)
+        .divisionIen("1")
+        .host(name + ".com")
+        .port(8888)
+        .timezone("America/New_York")
+        .build();
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void resolve(RpcRequest request, ConnectionDetails target, RpcPrincipal expected) {
+    assertThat(PrincipalResolution.of(request).resolve(target)).isEqualTo(expected);
+  }
+}

--- a/charon/src/test/java/gov/va/api/lighthouse/charon/service/controller/PrincipalResolutionTest.java
+++ b/charon/src/test/java/gov/va/api/lighthouse/charon/service/controller/PrincipalResolutionTest.java
@@ -16,15 +16,11 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class PrincipalResolutionTest {
-
-  static Stream<Arguments> resolve() {
-    return Stream.of(
-        arguments(request(), target("a"), principal("default")),
-        arguments(request("b", "c"), target("a"), principal("default")),
-        arguments(request("b", "c"), target("b"), principal("b")),
-        arguments(request("b", "c"), target("c"), principal("c"))
-        //
-        );
+  static RpcPrincipal principal(String name) {
+    return RpcPrincipal.standardUserBuilder()
+        .accessCode("ac-" + name)
+        .verifyCode("vc-" + name)
+        .build();
   }
 
   static RpcRequest request(String... specific) {
@@ -37,11 +33,12 @@ class PrincipalResolutionTest {
         .build();
   }
 
-  static RpcPrincipal principal(String name) {
-    return RpcPrincipal.standardUserBuilder()
-        .accessCode("ac-" + name)
-        .verifyCode("vc-" + name)
-        .build();
+  static Stream<Arguments> resolve() {
+    return Stream.of(
+        arguments(request(), target("a"), principal("default")),
+        arguments(request("b", "c"), target("a"), principal("default")),
+        arguments(request("b", "c"), target("b"), principal("b")),
+        arguments(request("b", "c"), target("c"), principal("c")));
   }
 
   static ConnectionDetails target(String name) {


### PR DESCRIPTION
- RpcRequest now includes an optional map of principals: siteSpecificPrincipals
- New integration test that uses bogus default rpc principals, but specifies good site specific prinicipals to ensure that site specific principals are used
- new PrincipalResolution utility to pick the best principal for a target
- Site specific principals can be applied per target site
- Documentation updated and request sample
