### PR TITLE
API 6746 site specific context

### DIFF
--- a/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcDetails.java
+++ b/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcDetails.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,7 @@ import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
@@ -154,6 +155,9 @@ public class RpcDetails {
 
   public static class ParameterValueDeserializer extends StdDeserializer<String> {
 
+    @Serial
+    private static final long serialVersionUID = 5543697039890338690L;
+
     public ParameterValueDeserializer() {
       super(String.class);
     }
@@ -166,6 +170,9 @@ public class RpcDetails {
   }
 
   public static class ParameterValueSerializer extends StdSerializer<String> {
+
+    @Serial
+    private static final long serialVersionUID = -4201150277421890777L;
 
     public ParameterValueSerializer() {
       super(String.class);

--- a/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcDetails.java
+++ b/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcDetails.java
@@ -155,8 +155,7 @@ public class RpcDetails {
 
   public static class ParameterValueDeserializer extends StdDeserializer<String> {
 
-    @Serial
-    private static final long serialVersionUID = 5543697039890338690L;
+    @Serial private static final long serialVersionUID = 5543697039890338690L;
 
     public ParameterValueDeserializer() {
       super(String.class);
@@ -171,8 +170,7 @@ public class RpcDetails {
 
   public static class ParameterValueSerializer extends StdSerializer<String> {
 
-    @Serial
-    private static final long serialVersionUID = -4201150277421890777L;
+    @Serial private static final long serialVersionUID = -4201150277421890777L;
 
     public ParameterValueSerializer() {
       super(String.class);

--- a/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcPrincipal.java
+++ b/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcPrincipal.java
@@ -23,11 +23,18 @@ public class RpcPrincipal {
   @NotBlank @NonNull private String verifyCode;
   /** Required for application proxy user. */
   private String applicationProxyUser;
+  /**
+   * For site specific principals, a different RPC context can be specified. This field is not valid
+   * for the default RPC request principal.
+   */
+  private String contextOverride;
 
   @Builder(builderMethodName = "standardUserBuilder", builderClassName = "StandardUserBuilder")
-  private RpcPrincipal(@NonNull String accessCode, @NonNull String verifyCode) {
+  private RpcPrincipal(
+      @NonNull String accessCode, @NonNull String verifyCode, String contextOverride) {
     this.accessCode = accessCode;
     this.verifyCode = verifyCode;
+    this.contextOverride = contextOverride;
   }
 
   @JsonCreator
@@ -37,10 +44,12 @@ public class RpcPrincipal {
   private RpcPrincipal(
       @JsonProperty("accessCode") @NonNull String accessCode,
       @JsonProperty("verifyCode") @NonNull String verifyCode,
-      @JsonProperty("applicationProxyUser") String applicationProxyUser) {
+      @JsonProperty("applicationProxyUser") String applicationProxyUser,
+      @JsonProperty("contextOverride") String contextOverride) {
     this.accessCode = accessCode;
     this.verifyCode = verifyCode;
     this.applicationProxyUser = applicationProxyUser;
+    this.contextOverride = contextOverride;
   }
 
   @SuppressWarnings("unused")

--- a/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcRequest.java
+++ b/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import java.util.HashMap;
 import java.util.Map;
 import javax.validation.Valid;
+import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
@@ -17,6 +18,11 @@ public class RpcRequest {
   @NotNull @Valid private RpcPrincipal principal;
   private Map<String, @Valid RpcPrincipal> siteSpecificPrincipals;
   @NotNull @Valid private RpcVistaTargets target;
+
+  @AssertTrue(message = "principal cannot specify contextOverride")
+  private boolean isPrincipalContextOverrideUnset() {
+    return principal.contextOverride() == null;
+  }
 
   /** Lazy initializer. */
   public Map<String, RpcPrincipal> siteSpecificPrincipals() {

--- a/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcRequest.java
+++ b/charon-api/src/main/java/gov/va/api/lighthouse/charon/api/RpcRequest.java
@@ -2,6 +2,7 @@ package gov.va.api.lighthouse.charon.api;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.HashMap;
 import java.util.Map;
 import javax.validation.Valid;
@@ -19,6 +20,8 @@ public class RpcRequest {
   private Map<String, @Valid RpcPrincipal> siteSpecificPrincipals;
   @NotNull @Valid private RpcVistaTargets target;
 
+  @JsonIgnore
+  @SuppressWarnings("unused")
   @AssertTrue(message = "principal cannot specify contextOverride")
   private boolean isPrincipalContextOverrideUnset() {
     return principal.contextOverride() == null;

--- a/charon-api/src/test/java/gov/va/api/lighthouse/charon/api/RpcRequestTest.java
+++ b/charon-api/src/test/java/gov/va/api/lighthouse/charon/api/RpcRequestTest.java
@@ -1,11 +1,14 @@
 package gov.va.api.lighthouse.charon.api;
 
 import static gov.va.api.lighthouse.charon.api.RoundTrip.assertRoundTrip;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import javax.validation.Validation;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -78,6 +81,15 @@ public class RpcRequestTest {
                         RpcDetails.Parameter.builder().namedArray(Map.of("d", "e")).build()))
                 .build())
         .build();
+  }
+
+  @Test
+  void principalWithContextOverrideIsInvalid() {
+    var validator = Validation.buildDefaultValidatorFactory().getValidator();
+    var request = v1();
+    assertThat(validator.validate(request)).isEmpty();
+    request.principal().contextOverride("NOPE");
+    assertThat(validator.validate(request)).isNotEmpty();
   }
 
   @ParameterizedTest

--- a/charon/requests/vpr-get-patient-data-xml-with-site-specific-principal-and-context.json
+++ b/charon/requests/vpr-get-patient-data-xml-with-site-specific-principal-and-context.json
@@ -1,0 +1,30 @@
+{
+  "principal": {
+    "accessCode":"NOPE$VISTA_ACCESS_CODE",
+    "verifyCode":"NOPE$VISTA_VERIFY_CODE"
+  },
+  "siteSpecificPrincipals": {
+    "673": {
+      "applicationProxyUser":"$VISTA_APP_PROXY_USER",
+      "accessCode":"$VISTA_APP_PROXY_ACCESS_CODE",
+      "verifyCode":"$VISTA_APP_PROXY_VERIFY_CODE",
+      "contextOverride":"LHS RPC CONTEXT"
+    }
+  },
+  "target": {
+    "forPatient": "195607"
+  },
+  "rpc": {
+    "name":"VPR GET PATIENT DATA",
+    "context":"NOPE",
+    "parameters": [
+      {"string":";195607"},
+      {"string":"demographics;vitals"},
+      {"string":""},
+      {"string":""},
+      {"string":""},
+      {"string":""},
+      {"array": []}
+    ]
+  }
+}


### PR DESCRIPTION
- RpcPrincipal now supports a contextOverride property that is legal in siteSpecificPrincipals but not on the default principal
- Charon now supports contextOverride for RPC requests to allow special RPC contexts to be used at different sites
