### PR TITLE
API-7606-basic-rpc-model

### DIFF
--- a/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/IblhsAmcmsGetIns.java
+++ b/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/IblhsAmcmsGetIns.java
@@ -1,19 +1,22 @@
 package gov.va.api.lighthouse.charon.models.iblhsamcmsgetins;
 
+import static java.util.stream.Collectors.toMap;
+
 import gov.va.api.lighthouse.charon.api.RpcDetails;
 import gov.va.api.lighthouse.charon.api.RpcInvocationResult;
 import gov.va.api.lighthouse.charon.models.TypeSafeRpc;
 import gov.va.api.lighthouse.charon.models.TypeSafeRpcRequest;
 import gov.va.api.lighthouse.charon.models.TypeSafeRpcResponse;
-import lombok.Builder;
-import lombok.NonNull;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
-import static java.util.stream.Collectors.toMap;
-
+/** Java model of the get insurance lighthouse RPC. */
+@NoArgsConstructor(staticName = "create")
 public class IblhsAmcmsGetIns
     implements TypeSafeRpc<IblhsAmcmsGetIns.Request, IblhsAmcmsGetIns.Response> {
 
@@ -48,6 +51,7 @@ public class IblhsAmcmsGetIns
   }
 
   /** Java representation of the RPC response per VistA site. */
+  @Data
   @Builder
   public static class Response implements TypeSafeRpcResponse {
     private Map<String, String> resultsByStation;

--- a/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/IblhsAmcmsGetIns.java
+++ b/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/IblhsAmcmsGetIns.java
@@ -1,0 +1,62 @@
+package gov.va.api.lighthouse.charon.models.iblhsamcmsgetins;
+
+import gov.va.api.lighthouse.charon.api.RpcDetails;
+import gov.va.api.lighthouse.charon.api.RpcInvocationResult;
+import gov.va.api.lighthouse.charon.models.TypeSafeRpc;
+import gov.va.api.lighthouse.charon.models.TypeSafeRpcRequest;
+import gov.va.api.lighthouse.charon.models.TypeSafeRpcResponse;
+import lombok.Builder;
+import lombok.NonNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+
+public class IblhsAmcmsGetIns
+    implements TypeSafeRpc<IblhsAmcmsGetIns.Request, IblhsAmcmsGetIns.Response> {
+
+  private static final String RPC_NAME = "IBLHS AMCMS GET INS";
+
+  private static final String RPC_CONTEXT = "IBLHS AMCMS RPCS";
+
+  @Override
+  public IblhsAmcmsGetIns.Response fromResults(List<RpcInvocationResult> results) {
+    return IblhsAmcmsGetIns.Response.builder()
+        .resultsByStation(
+            results.stream()
+                .filter(result -> result.error().isEmpty())
+                .collect(toMap(RpcInvocationResult::vista, RpcInvocationResult::response)))
+        .build();
+  }
+
+  /** Java representation of the RPC request. */
+  @Builder
+  public static class Request implements TypeSafeRpcRequest {
+
+    @NonNull private String icn;
+
+    @Override
+    public RpcDetails asDetails() {
+      return RpcDetails.builder()
+          .name(RPC_NAME)
+          .context(RPC_CONTEXT)
+          .parameters(List.of(RpcDetails.Parameter.builder().string(icn).build()))
+          .build();
+    }
+  }
+
+  /** Java representation of the RPC response per VistA site. */
+  @Builder
+  public static class Response implements TypeSafeRpcResponse {
+    private Map<String, String> resultsByStation;
+
+    Map<String, String> getResultsByStation() {
+      if (resultsByStation == null) {
+        resultsByStation = new HashMap<>();
+      }
+      return resultsByStation;
+    }
+  }
+}

--- a/charon-models/src/test/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/IblhsAmcmsGetInsTest.java
+++ b/charon-models/src/test/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/IblhsAmcmsGetInsTest.java
@@ -1,0 +1,49 @@
+package gov.va.api.lighthouse.charon.models.iblhsamcmsgetins;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.va.api.lighthouse.charon.api.RpcDetails;
+import gov.va.api.lighthouse.charon.api.RpcInvocationResult;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class IblhsAmcmsGetInsTest {
+
+  @Test
+  void fromResults() {
+    assertThat(IblhsAmcmsGetIns.create().fromResults(List.of()).getResultsByStation())
+        .isEqualTo(
+            IblhsAmcmsGetIns.Response.builder()
+                .resultsByStation(Map.of())
+                .build()
+                .getResultsByStation());
+    assertThat(
+            IblhsAmcmsGetIns.create()
+                .fromResults(
+                    List.of(
+                        RpcInvocationResult.builder()
+                            .vista("666")
+                            .error(Optional.of("4311"))
+                            .build(),
+                        RpcInvocationResult.builder().vista("888").response("Shanktopus!").build()))
+                .getResultsByStation())
+        .isEqualTo(
+            IblhsAmcmsGetIns.Response.builder()
+                .resultsByStation(Map.of("888", "Shanktopus!"))
+                .build()
+                .getResultsByStation());
+  }
+
+  @Test
+  void requestAsDetails() {
+    assertThat(IblhsAmcmsGetIns.Request.builder().icn("it-me").build().asDetails())
+        .isEqualTo(
+            RpcDetails.builder()
+                .name("IBLHS AMCMS GET INS")
+                .context("IBLHS AMCMS RPCS")
+                .parameters(List.of(RpcDetails.Parameter.builder().string("it-me").build()))
+                .build());
+  }
+}

--- a/charon/requests/iblhs-amcms-get-ins-request.json
+++ b/charon/requests/iblhs-amcms-get-ins-request.json
@@ -5,7 +5,7 @@
       "verifyCode":"$VISTA_VERIFY_CODE"
    },
    "target":{
-      "include":[ "host.docker.internal:18673:673:America/New_York" ]
+      "include":[ "localhost:18673:673:America/New_York" ]
    },
    "rpc":{
       "name":"IBLHS AMCMS GET INS",


### PR DESCRIPTION
# [API-7606](https://vajira.max.gov/browse/API-7606)
This pr creates the basic request model for the lighthouse get insurance rpc. Once merged, it will open up API-7608 for creating the `raw` api.