### PR TITLE
API-7980-rpc-models

### DIFF
--- a/charon-models/README.md
+++ b/charon-models/README.md
@@ -1,0 +1,6 @@
+# charon-models
+
+### IBLHS AMCMS GET INS
+- The Fileman File java models define only the fields that are listed in the insuranceElementList.xlsx located 
+  [here](https://libertyits.sharepoint.com/sites/AMCMS/Shared%20Documents/Forms/AllItems.aspx?csf=1&web=1&e=KiDYxm&cid=039212cd%2D3309%2D4056%2Dbfe1%2De24e6b46e527&RootFolder=%2Fsites%2FAMCMS%2FShared%20Documents%2FWellhive%20NI&FolderCTID=0x0120006BFCB76B4FFEDB4E85308A57BC09B287).
+    - Version: 179.0 

--- a/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/GetInsEntry.java
+++ b/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/GetInsEntry.java
@@ -16,7 +16,7 @@ import lombok.Value;
 public class GetInsEntry {
   @NonNull String fileNumber;
 
-  String ien;
+  @NonNull String ien;
 
   @NonNull String fieldNumber;
 

--- a/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/GetInsEntry.java
+++ b/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/GetInsEntry.java
@@ -1,0 +1,26 @@
+package gov.va.api.lighthouse.charon.models.iblhsamcmsgetins;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+/**
+ * Models the fields expected in the caret separated string from the IBLHS AMCMS GET INS RPC.
+ *
+ * <p>Expected string representation:
+ *
+ * <p>File#^Internal Entry Number^Field#^External format value^Internal format value
+ */
+@Value
+@Builder
+public class GetInsEntry {
+  @NonNull String fileNumber;
+
+  String ien;
+
+  @NonNull String fieldNumber;
+
+  String externalValueRepresentation;
+
+  String internalValueRepresentation;
+}

--- a/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/InsuranceCompanyFile.java
+++ b/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/InsuranceCompanyFile.java
@@ -3,7 +3,11 @@ package gov.va.api.lighthouse.charon.models.iblhsamcmsgetins;
 import lombok.Builder;
 import lombok.Data;
 
-/** Java representation of Fileman file #36 in VistA. */
+/**
+ * Java representation of Fileman file #36 in VistA.
+ *
+ * <p>Currently using insuranceElementList.xlsx version: 179.0
+ */
 @Data
 @Builder
 public class InsuranceCompanyFile {

--- a/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/InsuranceCompanyFile.java
+++ b/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/InsuranceCompanyFile.java
@@ -3,11 +3,7 @@ package gov.va.api.lighthouse.charon.models.iblhsamcmsgetins;
 import lombok.Builder;
 import lombok.Data;
 
-/**
- * Java representation of Fileman file #36 in VistA.
- *
- * <p>Currently using insuranceElementList.xlsx version: 179.0
- */
+/** Java representation of Fileman file #36 in VistA. */
 @Data
 @Builder
 public class InsuranceCompanyFile {

--- a/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/InsuranceCompanyFile.java
+++ b/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/iblhsamcmsgetins/InsuranceCompanyFile.java
@@ -1,0 +1,229 @@
+package gov.va.api.lighthouse.charon.models.iblhsamcmsgetins;
+
+import lombok.Builder;
+import lombok.Data;
+
+/** Java representation of Fileman file #36 in VistA. */
+@Data
+@Builder
+public class InsuranceCompanyFile {
+  private GetInsEntry name;
+
+  private GetInsEntry allowMultipleBedsections;
+
+  private GetInsEntry differentRevenueCodesToUse;
+
+  private GetInsEntry oneOptVisitOnBillOnly;
+
+  private GetInsEntry ambulatorySurgRevCode;
+
+  private GetInsEntry streetAddressLine1;
+
+  private GetInsEntry streetAddressLine2;
+
+  private GetInsEntry streetAddressLine3;
+
+  private GetInsEntry city;
+
+  private GetInsEntry state;
+
+  private GetInsEntry zipCode;
+
+  private GetInsEntry billingCompanyName;
+
+  private GetInsEntry faxNumber;
+
+  private GetInsEntry filingTimeFrame;
+
+  private GetInsEntry claimsInptStreetAddress1;
+
+  private GetInsEntry claimsInptStreetAddress2;
+
+  private GetInsEntry claimsInptStreetAddress3;
+
+  private GetInsEntry claimsInptProcessCity;
+
+  private GetInsEntry claimsInptProcessState;
+
+  private GetInsEntry claimsInptProcessZip;
+
+  private GetInsEntry claimsInptCompanyName;
+
+  private GetInsEntry anotherCoProcessIpClaims;
+
+  private GetInsEntry claimsInptFax;
+
+  private GetInsEntry typeOfCoverage;
+
+  private GetInsEntry phoneNumber;
+
+  private GetInsEntry claimsRxPhoneNumber;
+
+  private GetInsEntry billingPhoneNumber;
+
+  private GetInsEntry precertificationPhoneNumber;
+
+  private GetInsEntry verificationPhoneNumber;
+
+  private GetInsEntry claimsInptPhoneNumber;
+
+  private GetInsEntry claimsOptPhoneNumber;
+
+  private GetInsEntry appealsPhoneNumber;
+
+  private GetInsEntry inquiryPhoneNumber;
+
+  private GetInsEntry precertCompanyName;
+
+  private GetInsEntry appealsAddressStLine1;
+
+  private GetInsEntry appealsAddressStLine2;
+
+  private GetInsEntry appealsAddressStLine3;
+
+  private GetInsEntry appealsAddressCity;
+
+  private GetInsEntry appealsAddressState;
+
+  private GetInsEntry appealsAddressZip;
+
+  private GetInsEntry appealsCompanyName;
+
+  private GetInsEntry anotherCoProcessAppeals;
+
+  private GetInsEntry appealsFax;
+
+  private GetInsEntry prescriptionRefillRevCode;
+
+  private GetInsEntry inquiryAddressStLine1;
+
+  private GetInsEntry inquiryAddressStLine2;
+
+  private GetInsEntry inquiryAddressStLine3;
+
+  private GetInsEntry inquiryAddressCity;
+
+  private GetInsEntry inquiryAddressState;
+
+  private GetInsEntry inquiryAddressZipCode;
+
+  private GetInsEntry inquiryCompanyName;
+
+  private GetInsEntry anotherCoProcessingInquiries;
+
+  private GetInsEntry inquiryFax;
+
+  private GetInsEntry claimsOptStreetAddress1;
+
+  private GetInsEntry claimsOptStreetAddress2;
+
+  private GetInsEntry claimsOptStreetAddress3;
+
+  private GetInsEntry claimsOptProcessCity;
+
+  private GetInsEntry claimsOptProcessState;
+
+  private GetInsEntry claimsOptProcessZip;
+
+  private GetInsEntry claimsOptCompanyName;
+
+  private GetInsEntry anotherCoProcessOpClaims;
+
+  private GetInsEntry claimsOptFax;
+
+  private GetInsEntry anotherCoProcessPrecerts;
+
+  private GetInsEntry claimsRxStreetAddress1;
+
+  private GetInsEntry claimsRxStreetAddress2;
+
+  private GetInsEntry claimsRxStreetAddress3;
+
+  private GetInsEntry claimsRxCity;
+
+  private GetInsEntry claimsRxState;
+
+  private GetInsEntry claimsRxZip;
+
+  private GetInsEntry claimsRxCompanyName;
+
+  private GetInsEntry anotherCoProcessRxClaims;
+
+  private GetInsEntry claimsRxFax;
+
+  private GetInsEntry standardFtfValue;
+
+  private GetInsEntry claimsDentalPhoneNumber;
+
+  private GetInsEntry claimsDentalStreetAddr1;
+
+  private GetInsEntry claimsDentalStreetAddr2;
+
+  private GetInsEntry claimsDentalProcessCity;
+
+  private GetInsEntry claimsDentalProcessState;
+
+  private GetInsEntry claimsDentalProcessZip;
+
+  private GetInsEntry claimsDentalCompanyName;
+
+  private GetInsEntry anotherCoProcDentClaims;
+
+  private GetInsEntry claimsDentalFax;
+
+  private GetInsEntry reimburse;
+
+  private GetInsEntry signatureRequiredOnBill;
+
+  private GetInsEntry transmitElectronically;
+
+  private GetInsEntry ediIdNumberProf;
+
+  private GetInsEntry binNumber;
+
+  private GetInsEntry ediIdNumberInst;
+
+  private GetInsEntry electronicInsuranceType;
+
+  private GetInsEntry payer;
+
+  private GetInsEntry ediIdNumberDental;
+
+  private GetInsEntry perfProvSecondIdType1500;
+
+  private GetInsEntry perfProvSecondIdTypeUb;
+
+  private GetInsEntry secondaryIdRequirements;
+
+  private GetInsEntry refProvSecIdDefCms1500;
+
+  private GetInsEntry refProvSecIdReqOnClaims;
+
+  private GetInsEntry attRendIdBillSecIdProf;
+
+  private GetInsEntry attRendIdBillSecIdInst;
+
+  private GetInsEntry ediInstSecondaryIdQual1;
+
+  private GetInsEntry ediInstSecondaryId1;
+
+  private GetInsEntry ediInstSecondaryIdQual2;
+
+  private GetInsEntry ediInstSecondaryId2;
+
+  private GetInsEntry ediProfSecondaryIdQual1;
+
+  private GetInsEntry ediProfSecondaryId1;
+
+  private GetInsEntry ediProfSecondaryIdQual2;
+
+  private GetInsEntry ediProfSecondaryId2;
+
+  private GetInsEntry printSecTertAutoClaims;
+
+  private GetInsEntry printSecMedClaimsWoMra;
+
+  private GetInsEntry ediUmo278Id;
+
+  private GetInsEntry x277EdiIdNumber;
+}


### PR DESCRIPTION
# [API-7980](https://vajira.max.gov/browse/API-7980)
This is just the models for the expected entry as well as the fields we expect to be using from the insurance company file. The latter can be validated against the [spreadsheet](https://libertyits.sharepoint.com/:x:/r/sites/AMCMS/_layouts/15/Doc.aspx?sourcedoc=%7B728E8C4D-46FF-49F6-A5A1-E554BFCAB957%7D&file=insuranceElementList.xlsx&action=default&mobileredirect=true) in sharepoint.