### PR TITLE
Add lazy initializer to Meds product

### DIFF
--- a/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/vprgetpatientdata/Meds.java
+++ b/charon-models/src/main/java/gov/va/api/lighthouse/charon/models/vprgetpatientdata/Meds.java
@@ -102,6 +102,14 @@ public class Meds {
     @JacksonXmlElementWrapper(localName = "products")
     List<Product> product;
 
+    /** Lazy Initializer. */
+    public List<Product> product() {
+      if (product == null) {
+        product = new ArrayList<>();
+      }
+      return product;
+    }
+
     @JacksonXmlProperty ValueOnlyXmlAttribute ptInstructions;
 
     @JacksonXmlProperty ValueOnlyXmlAttribute quantity;

--- a/charon-models/src/test/java/gov/va/api/lighthouse/charon/models/vprgetpatientdata/MedsTest.java
+++ b/charon-models/src/test/java/gov/va/api/lighthouse/charon/models/vprgetpatientdata/MedsTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import gov.va.api.lighthouse.charon.api.RpcInvocationResult;
 import gov.va.api.lighthouse.charon.models.CodeAndNameXmlAttribute;
 import gov.va.api.lighthouse.charon.models.ValueOnlyXmlAttribute;
+import gov.va.api.lighthouse.charon.models.vprgetpatientdata.Meds.Med;
+import gov.va.api.lighthouse.charon.models.vprgetpatientdata.Meds.Med.Product;
 import io.micrometer.core.instrument.util.IOUtils;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -183,5 +185,13 @@ public class MedsTest {
             .medStream()
             .collect(Collectors.toList());
     assertThat(sample).isEqualTo(medsSamples.medResults());
+  }
+
+  @Test
+  void productIsEmpty() {
+    Med medNullProduct = Med.builder().product(null).build();
+    Med medEmptyProduct = Med.builder().product(List.of()).build();
+    assertThat(medNullProduct.product()).isEmpty();
+    assertThat(medEmptyProduct.product()).isEmpty();
   }
 }


### PR DESCRIPTION
Lazy initializer on Meds product to return empty list instead of null

Co-authored-by: Joshua Miller <jmiller@rise8.us>
Co-authored-by: Thomas Reynolds <treynolds@rise8.us>